### PR TITLE
API alterations for mcrouter

### DIFF
--- a/README
+++ b/README
@@ -28,6 +28,7 @@ option to `ktserver`:
 
 * `host`: sets the hostname for the listening socket [default: localhost]
 * `port`: sets the port number for the listening socket [default: 6080]
+* `url_prefix`: sets the URL prefix to prepend to the key (e.g. the IAS server endpoint)
 * `server_threads`: number of threads to handle memcached requests [default: 16]
 * `fetcher_threads`: number of threads to handle background HTTP fetches [default: 16]
 * `ttl`: number of seconds for which cached results are served before re-fetching
@@ -52,9 +53,16 @@ described in [the memcached protocol
 documentation](https://github.com/memcached/memcached/blob/master/doc/protocol.txt);
 `get` works differently by necessity. All other commands are not supported.
 
-The `get` command accepts 2 or 3 arguments:
+The `get` command accepts 1 to 3 arguments:
 
-    get key url [ttl]
+One argument (key is appended to `url_prefix` to populate the cache):
+    get <key>
+
+Two arguments (the URL is used to populate the cache, the key can be anything):
+    get <key> <url>
+
+Three arguments (NOTE: TTL override is only supported for the 3 argument version):
+    get <key> <url> [ttl]
 
 The `key` is a unique key within the cache. If a value for the key already
 exists, then the cached contents of the `url` is immediately returned; if
@@ -72,14 +80,25 @@ specified.
 
 CacheOrBust uses autotools, which can be installed through your
 distribution's package manager, and depends on libraries and headers from
-Kyoto Cabinet and Kyoto Tycoon, which can be found at http://fallabs.com/.
+Kyoto Cabinet (http://fallabs.com/kyotocabinet/) and Kyoto Tycoon (http://fallabs.com/kyototycoon/).
+
+On CenOS 7 the following packages should be installed first:
+    $ sudo yum install autoconf make automake gcc gcc-c++ libtool kyototycoon-devel kyotocabinet-devel
+    NOTE: The kyoto*devel packages are in the Magnetic RPM repository
 
 With dependencies installed, you can configure the build environment with:
 
-    $ autoreconf
-    $ ./configure
+    $ autoreconf --force --install
+    $ sed -i -e 's/ -g0 -O2//' -e 's/ -O0//' configure
+    $ sed -i -e 's/ -g0 -O2//' -e 's/ -O0//' Makefile.am
+    $ ./configure --prefix=/usr
 
 And then build the CacheOrBust shared object library with:
 
     $ make
     $ [sudo] make install
+
+Sample run command:
+    $ ktserver -ls -port 6000 -plsv ./.libs/ktcacheorbust-1.0.so \
+      -plex "port=7000#ttl=86400#server_threads=16#fetcher_threads=32#keepalive=false" \
+      '*#opts=l#bnum=1048583#ktcapsiz=40g#capsiz=40g#dfunit=8'

--- a/README
+++ b/README
@@ -56,12 +56,15 @@ documentation](https://github.com/memcached/memcached/blob/master/doc/protocol.t
 The `get` command accepts 1 to 3 arguments:
 
 One argument (key is appended to `url_prefix` to populate the cache):
+
     get <key>
 
 Two arguments (the URL is used to populate the cache, the key can be anything):
+
     get <key> <url>
 
 Three arguments (NOTE: TTL override is only supported for the 3 argument version):
+
     get <key> <url> [ttl]
 
 The `key` is a unique key within the cache. If a value for the key already
@@ -83,6 +86,7 @@ distribution's package manager, and depends on libraries and headers from
 Kyoto Cabinet (http://fallabs.com/kyotocabinet/) and Kyoto Tycoon (http://fallabs.com/kyototycoon/).
 
 On CenOS 7 the following packages should be installed first:
+
     $ sudo yum install autoconf make automake gcc gcc-c++ libtool kyototycoon-devel kyotocabinet-devel
     NOTE: The kyoto*devel packages are in the Magnetic RPM repository
 
@@ -99,6 +103,7 @@ And then build the CacheOrBust shared object library with:
     $ [sudo] make install
 
 Sample run command:
+
     $ ktserver -ls -port 6000 -plsv ./.libs/ktcacheorbust-1.0.so \
       -plex "port=7000#ttl=86400#server_threads=16#fetcher_threads=32#keepalive=false" \
       '*#opts=l#bnum=1048583#ktcapsiz=40g#capsiz=40g#dfunit=8'

--- a/README
+++ b/README
@@ -29,12 +29,14 @@ option to `ktserver`:
 * `host`: sets the hostname for the listening socket [default: localhost]
 * `port`: sets the port number for the listening socket [default: 6080]
 * `url_prefix`: sets the URL prefix to prepend to the key (e.g. the IAS server endpoint)
+* `strip_prefix`: sets the URL prefix to prepend to the key (e.g. the IAS server endpoint)
 * `server_threads`: number of threads to handle memcached requests [default: 16]
 * `fetcher_threads`: number of threads to handle background HTTP fetches [default: 16]
 * `ttl`: number of seconds for which cached results are served before re-fetching
   from the upstream server [default: 3600]
 * `keepalive`: if "true", background HTTP requests will use HTTP Keep-Alive
    requests when requesting multiple URLs from the same host [default: false]
+* `log_keys`: if "true", log keys requested at the INFO level [default: false]
 
 A good starting point is:
 
@@ -85,7 +87,7 @@ CacheOrBust uses autotools, which can be installed through your
 distribution's package manager, and depends on libraries and headers from
 Kyoto Cabinet (http://fallabs.com/kyotocabinet/) and Kyoto Tycoon (http://fallabs.com/kyototycoon/).
 
-On CenOS 7 the following packages should be installed first:
+On CentOS 7 the following packages should be installed first:
 
     $ sudo yum install autoconf make automake gcc gcc-c++ libtool kyototycoon-devel kyotocabinet-devel
     NOTE: The kyoto*devel packages are in the Magnetic RPM repository

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([cacheorbust], [0.3.3], [dcrosta@late.am])
+AC_INIT([cacheorbust], [0.4.0], [dcrosta@late.am])
 
 AM_INIT_AUTOMAKE([-Wall -Werror])
 

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -201,14 +201,6 @@ bool CacheOrBust::Worker::do_get(
   } else {
     _opcounts[tid][MISS]++;
 
-    std::string url;
-    if (tokens.size() >= 3)
-      url = tokens[2];
-    else if (!_serv->_url_prefix.empty())
-      url = _serv->_url_prefix + decoded_key;
-    else
-      return sess->printf("CLIENT_ERROR missing URL\r\n");
-
     // add sentinel record, TTL 30s so that another
     // cache miss in 30s will cause another background
     // fetch to be enqueued
@@ -218,8 +210,6 @@ bool CacheOrBust::Worker::do_get(
       return true;
     }
 
-    sess->printf("END\r\n");
-
     std::string decoded_key(tokens[1]);
     if (! key.compare(0, 4, "http")) {
       // Assume the string is base64 encoded if it doesn't start with "http"
@@ -228,6 +218,16 @@ bool CacheOrBust::Worker::do_get(
       if (temp_decoded.size() >= 8)
         decoded_key = temp_decoded;
     }
+
+    std::string url;
+    if (tokens.size() >= 3)
+      url = tokens[2];
+    else if (!_serv->_url_prefix.empty())
+      url = _serv->_url_prefix + decoded_key;
+    else
+      return sess->printf("CLIENT_ERROR missing URL\r\n");
+
+    sess->printf("END\r\n");
 
     // NOTE: ttl is not supported for url_prefix mode, only here for backwards compatibility
     if (tokens.size() == 4)

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -72,9 +72,9 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
   }
 
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust parameters:");
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: host='%s'", _host);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: host='%s'", _host.c_str());
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: port='%d'", _port);
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: url_prefix='%s'", _url_prefix);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: url_prefix='%s'", _url_prefix.c_str());
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: server_threads='%d'", _server_threads);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: fetcher_threads='%d'", _fetcher_threads);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: ttl='%d'", _ttl);

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -70,6 +70,16 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
     }
     ++it;
   }
+
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust parameters:");
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: host='%s'", _host);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: port='%d'", _port);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: url_prefix='%s'", _url_prefix);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: server_threads='%d'", _server_threads);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: fetcher_threads='%d'", _fetcher_threads);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: ttl='%d'", _ttl);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: keepalive='%s'", _use_keepalive ? "true" : "false");
+
 }
 
 bool CacheOrBust::start()

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -234,7 +234,7 @@ bool CacheOrBust::Worker::do_get(
       ttl = kc::atoi(tokens[3].c_str());
 
     FetchTask* fetch = new FetchTask(key, url, ttl);
-    _serv->_queue->add_task(fetch); // It would be nice to only add things that aren't already in the queue
+    _serv->_queue->add_task(fetch);
     _opcounts[tid][ENQUEUE]++;
   }
   return true;

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -143,6 +143,8 @@ bool CacheOrBust::Worker::process(kt::ThreadedServer* serv, kt::ThreadedServer::
       success = do_stats(serv, sess, tokens, db);
     } else if (cmd == "flush_all") {
       success = do_flush(serv, sess, tokens, db);
+    } else if (cmd == "version") {
+      sess->printf("VERSION CacheOrBust/%s,KyotoTycoon/%s\r\n", PACKAGE_VERSION, kt::VERSION);
     } else if (cmd == "quit") {
       success = false;
     } else {

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -80,6 +80,7 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: host='%s'", _host.c_str());
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: port='%d'", _port);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: url_prefix='%s'", _url_prefix.c_str());
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: strip_prefix='%s'", _strip_prefix.c_str());
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: server_threads='%d'", _server_threads);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: fetcher_threads='%d'", _fetcher_threads);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: ttl='%d'", _ttl);

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -190,7 +190,7 @@ bool CacheOrBust::Worker::do_get(
     const char flags = data[0];
     if (flags & FLAG_PENDING) {
       _opcounts[tid][MISS]++;
-      sess->printf("END\r\n", key.c_str());
+      sess->printf("END\r\n");
     } else {
       _opcounts[tid][HIT]++;
       sess->printf("VALUE %s 0 %llu\r\n", key.c_str(), datasize - 1);
@@ -200,7 +200,7 @@ bool CacheOrBust::Worker::do_get(
     delete[] data;
   } else {
     _opcounts[tid][MISS]++;
-    sess->printf("END\r\n", key.c_str());
+    sess->printf("END\r\n");
 
     // add sentinel record, TTL 30s so that another
     // cache miss in 30s will cause another background

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -38,35 +38,29 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
   std::vector<std::string>::iterator it = elems.begin();
   std::vector<std::string>::iterator itend = elems.end();
   while (it != itend) {
-    std::vector<std::string> fields;
-    if (kc::strsplit(*it, '=', &fields) > 1) {
-      const char* key = fields[0].c_str();
+    std::string param = *it;
+    std::size_t found = param.find("=");
 
-      // Join everything back together with =
-      std::string temp_value;
-      std::vector<std::string>::iterator fit = fields.begin();
-      std::vector<std::string>::iterator fitend = fields.end();
-      ++fit; // Ignore the first value
-      temp_value += *fit++;
-      for (; fit != fitend; ++fit) temp_value.append("=").append(*fit);
+    if (found!=std::string::npos) {
+      std::string key = param.substr(0, found);
+      std::string value = param.substr(found+1);
 
-      const char* value = temp_value.c_str();
-      if (!std::strcmp(key, "host")) {
+      if (!key.compare("host")) {
         _host = value;
-      } else if (!std::strcmp(key, "port")) {
-        _port = kc::atoi(value);
-      } else if (!std::strcmp(key, "url_prefix")) {
+      } else if (!key.compare("port")) {
+        _port = kc::atoi(value.c_str());
+      } else if (!key.compare("url_prefix")) {
         _url_prefix = value;
-      } else if (!std::strcmp(key, "server_threads")) {
-        _server_threads = kc::atoi(value);
-      } else if (!std::strcmp(key, "fetcher_threads")) {
-        _fetcher_threads = kc::atoi(value);
-      } else if (!std::strcmp(key, "ttl")) {
-        _ttl = kc::atoi(value);
-      } else if (!std::strcmp(key, "keepalive")) {
-        if (!std::strcmp(value, "true")) {
+      } else if (!key.compare("server_threads")) {
+        _server_threads = kc::atoi(value.c_str());
+      } else if (!key.compare("fetcher_threads")) {
+        _fetcher_threads = kc::atoi(value.c_str());
+      } else if (!key.compare("ttl")) {
+        _ttl = kc::atoi(value.c_str());
+      } else if (!key.compare("keepalive")) {
+        if (!value.compare("true")) {
           _use_keepalive = true;
-        } else if (!std::strcmp(value, "false")) {
+        } else if (!value.compare("false")) {
           _use_keepalive = false;
         } else {
           log(kt::ThreadedServer::Logger::ERROR, "keepalive value must be 'true' or 'false' (assuming 'true')");

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -41,13 +41,22 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
     std::vector<std::string> fields;
     if (kc::strsplit(*it, '=', &fields) > 1) {
       const char* key = fields[0].c_str();
-      const char* value = fields[1].c_str();
+
+      // Join everything back together with =
+      std::string temp_value;
+      std::vector<std::string>::iterator fit = fields.begin();
+      std::vector<std::string>::iterator fitend = fields.end();
+      ++fit; // Ignore the first value
+      temp_value += *fit++;
+      for (; fit != fitend; ++fit) temp_value.append("=").append(*fit);
+
+      const char* value = temp_value.c_str();
       if (!std::strcmp(key, "host")) {
         _host = value;
       } else if (!std::strcmp(key, "port")) {
         _port = kc::atoi(value);
       } else if (!std::strcmp(key, "url_prefix")) {
-          _url_prefix = value;
+        _url_prefix = value;
       } else if (!std::strcmp(key, "server_threads")) {
         _server_threads = kc::atoi(value);
       } else if (!std::strcmp(key, "fetcher_threads")) {

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -45,20 +45,10 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
       std::string key = param.substr(0, found);
       std::string value = param.substr(found+1);
 
-      if (!key.compare("host")) {
-        _host = value;
-      } else if (!key.compare("port")) {
-        _port = kc::atoi(value.c_str());
-      } else if (!key.compare("url_prefix")) {
-        _url_prefix = value;
-      } else if (!key.compare("strip_prefix")) {
-        _strip_prefix = value;
-      } else if (!key.compare("server_threads")) {
-        _server_threads = kc::atoi(value.c_str());
-      } else if (!key.compare("fetcher_threads")) {
+      if (!key.compare("fetcher_threads")) {
         _fetcher_threads = kc::atoi(value.c_str());
-      } else if (!key.compare("ttl")) {
-        _ttl = kc::atoi(value.c_str());
+      } else if (!key.compare("host")) {
+        _host = value;
       } else if (!key.compare("keepalive")) {
         if (!value.compare("true")) {
           _use_keepalive = true;
@@ -75,6 +65,16 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
         } else {
           log(kt::ThreadedServer::Logger::ERROR, "log_keys value must be 'true' or 'false' (assuming 'false')");
         }
+      } else if (!key.compare("port")) {
+        _port = kc::atoi(value.c_str());
+      } else if (!key.compare("server_threads")) {
+        _server_threads = kc::atoi(value.c_str());
+      } else if (!key.compare("strip_prefix")) {
+        _strip_prefix = value;
+      } else if (!key.compare("ttl")) {
+        _ttl = kc::atoi(value.c_str());
+      } else if (!key.compare("url_prefix")) {
+        _url_prefix = value;
       } else {
         std::stringstream err;
         err << "CacheOrBust: unknown option '" << key << "'";
@@ -85,15 +85,15 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
   }
 
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust parameters:");
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: host='%s'", _host.c_str());
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: port='%d'", _port);
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: url_prefix='%s'", _url_prefix.c_str());
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: strip_prefix='%s'", _strip_prefix.c_str());
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: server_threads='%d'", _server_threads);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: fetcher_threads='%d'", _fetcher_threads);
-  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: ttl='%d'", _ttl);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: host='%s'", _host.c_str());
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: keepalive='%s'", _use_keepalive ? "true" : "false");
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: log_keys='%s'", _log_keys ? "true" : "false");
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: port='%d'", _port);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: server_threads='%d'", _server_threads);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: strip_prefix='%s'", _strip_prefix.c_str());
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: ttl='%d'", _ttl);
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: url_prefix='%s'", _url_prefix.c_str());
 
 }
 
@@ -194,7 +194,9 @@ bool CacheOrBust::Worker::do_get(
   }
 
   if (! _serv->_strip_prefix.empty() && ! key.compare(0, _serv->_strip_prefix.length(), _serv->_strip_prefix)) {
-    // Strip leading prefix from key (for mcrouter prefix-routing)
+    // Strip leading prefix from key (for mcrouter Prefix Routing)
+    // If you set strip_prefix to "cob:" then "cob:key" and "key" will both match the same key.
+    // Prefix Routing is defined here: https://github.com/facebook/mcrouter/wiki/Prefix-routing-setup
     key.erase(0, _serv->_strip_prefix.length());
   }
 

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -93,6 +93,7 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: fetcher_threads='%d'", _fetcher_threads);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: ttl='%d'", _ttl);
   log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: keepalive='%s'", _use_keepalive ? "true" : "false");
+  log(kt::ThreadedServer::Logger::SYSTEM, "CacheOrBust: log_keys='%s'", _log_keys ? "true" : "false");
 
 }
 

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -179,6 +179,10 @@ bool CacheOrBust::Worker::do_get(
     return sess->printf("CLIENT_ERROR extra data after TTL\r\n");
 
   std::string key(tokens[1]);
+  if (! key.compare(0, 4, "ias:")) {
+    // Strip leading "ias:" from key (for mcrouter prefix-based routing)
+    key.erase(0, 4);
+  }
 
   size_t datasize;
   char* data = db->get(key.data(), key.size(), &datasize);
@@ -208,8 +212,7 @@ bool CacheOrBust::Worker::do_get(
     }
 
     std::string decoded_key(tokens[1]);
-    std::string test_http_prefix("http");
-    if (! key.compare(0, test_http_prefix.size(), test_http_prefix)) {
+    if (! key.compare(0, 4, "http")) {
       // Assume the string is base64 encoded if it doesn't start with "http"
       std::string temp_decoded = b64decode(key);
       // Super basic sanity check of decoded key.  Min length of http://a

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -189,13 +189,7 @@ bool CacheOrBust::Worker::do_get(
   std::string key(tokens[1]);
 
   if (_serv->_log_keys) {
-    std::string escaped_key = key;
-    size_t pos = 0;
-    while((pos = escaped_key.find("%", pos)) != std::string::npos) {
-      escaped_key.replace(pos, 1, "%%");
-      pos += 2;
-    }
-    _serv->log(kt::ThreadedServer::Logger::INFO, "COB key request: %s", escaped_key.c_str());
+    _serv->log(kt::ThreadedServer::Logger::INFO, "COB key request: %s", key.c_str());
   }
 
   if (! _serv->_strip_prefix.empty() && ! key.compare(0, _serv->_strip_prefix.length(), _serv->_strip_prefix)) {

--- a/ktcacheorbust.cc
+++ b/ktcacheorbust.cc
@@ -51,6 +51,8 @@ void CacheOrBust::configure(kt::TimedDB* dbary, size_t dbnum,
         _port = kc::atoi(value.c_str());
       } else if (!key.compare("url_prefix")) {
         _url_prefix = value;
+      } else if (!key.compare("strip_prefix")) {
+        _strip_prefix = value;
       } else if (!key.compare("server_threads")) {
         _server_threads = kc::atoi(value.c_str());
       } else if (!key.compare("fetcher_threads")) {
@@ -175,9 +177,9 @@ bool CacheOrBust::Worker::do_get(
     return sess->printf("CLIENT_ERROR extra data after TTL\r\n");
 
   std::string key(tokens[1]);
-  if (! key.compare(0, 4, "ias:")) {
-    // Strip leading "ias:" from key (for mcrouter prefix-based routing)
-    key.erase(0, 4);
+  if (! _serv->_strip_prefix.empty() && ! key.compare(0, _serv->_strip_prefix.length(), _serv->_strip_prefix)) {
+    // Strip leading prefix from key (for mcrouter prefix-routing)
+    key.erase(0, _serv->_strip_prefix.length());
   }
 
   size_t datasize;

--- a/ktcacheorbust.h
+++ b/ktcacheorbust.h
@@ -45,6 +45,7 @@ namespace cob {
       uint32_t _fetcher_threads;
       uint32_t _ttl;
       bool _use_keepalive;
+      bool _log_keys = false;
 
       OpCounts _opcounts;
 

--- a/ktcacheorbust.h
+++ b/ktcacheorbust.h
@@ -40,6 +40,7 @@ namespace cob {
       std::string _host;
       int32_t _port;
       std::string _url_prefix;
+      std::string _strip_prefix;
       uint32_t _server_threads;
       uint32_t _fetcher_threads;
       uint32_t _ttl;

--- a/ktcacheorbust.h
+++ b/ktcacheorbust.h
@@ -131,10 +131,6 @@ namespace cob {
               const std::vector<std::string>& tokens, kt::TimedDB* db);
           bool do_stats(kt::ThreadedServer* serv, kt::ThreadedServer::Session* sess,
               const std::vector<std::string>& tokens, kt::TimedDB* db);
-
-          std::string b64decode(const void* data, const size_t len);
-          std::string b64decode(const std::string& str64);
-
       };
   };
 };

--- a/ktcacheorbust.h
+++ b/ktcacheorbust.h
@@ -39,6 +39,7 @@ namespace cob {
 
       std::string _host;
       int32_t _port;
+      std::string _url_prefix;
       uint32_t _server_threads;
       uint32_t _fetcher_threads;
       uint32_t _ttl;
@@ -130,6 +131,10 @@ namespace cob {
               const std::vector<std::string>& tokens, kt::TimedDB* db);
           bool do_stats(kt::ThreadedServer* serv, kt::ThreadedServer::Session* sess,
               const std::vector<std::string>& tokens, kt::TimedDB* db);
+
+          std::string b64decode(const void* data, const size_t len);
+          std::string b64decode(const std::string& str64);
+
       };
   };
 };

--- a/ktcacheorbust.h
+++ b/ktcacheorbust.h
@@ -45,7 +45,7 @@ namespace cob {
       uint32_t _fetcher_threads;
       uint32_t _ttl;
       bool _use_keepalive;
-      bool _log_keys = false;
+      bool _log_keys;
 
       OpCounts _opcounts;
 
@@ -63,6 +63,7 @@ namespace cob {
           _fetcher_threads(0),
           _ttl(0),
           _use_keepalive(true),
+          _log_keys(false),
           _serv(),
           _opcounts()
       {


### PR DESCRIPTION
* Add support for setting a `url_prefix` in the cacheorbust config instead of having to pass 2 parameters to `get` (which mcrouter doesn't support)
* Added support for stripping a leading `strip_prefix` from the key so we can use mcrouter's prefix routing 
* Add support for `version` (which seems to be used by mcrouter to check health)
to direct keys to different pools
* Add support for `log_keys` which will log keys to INFO
* Print out the settings on startup
* Bump version to 0.4.0
